### PR TITLE
prefix package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pg-js",
+  "name": "@portchain/pg-js",
   "version": "0.6.0",
   "description": "PostgreSQL to javascript API generator",
   "main": "pg-js.js",


### PR DESCRIPTION
We forked pg-js as we need to release a new version of the package with a more recent pg dependency.
