### PR TITLE
pg@8.5.1

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "jsonlint": "1.6.2",
     "lodash": "4.6.0",
-    "pg": "6.0.1",
+    "pg": "8.5.1",
     "serial": "0.0.9",
     "wrench": "1.5.8"
   }


### PR DESCRIPTION
We want all our applications to depend on the same version of pg, which necessitates upgrading our transitive dependencies.
